### PR TITLE
Fix error: No instance for (Applicative (Editor b)) 

### DIFF
--- a/07-folds-monoids/Editor.hs
+++ b/07-folds-monoids/Editor.hs
@@ -35,7 +35,7 @@ commands = map show [View, Edit, Next, Prev, Quit]
 -- Editor monad
 
 newtype Editor b a = Editor (StateT (b,Int) IO a)
-  deriving (Functor, Monad, MonadIO, MonadState (b,Int))
+  deriving (Functor, Applicative, Monad, MonadIO, MonadState (b,Int))
 
 runEditor :: Buffer b => Editor b a -> b -> IO a
 runEditor (Editor e) b = evalStateT e (b,0)


### PR DESCRIPTION
Fix No instance for (Applicative (Editor b)) arising from the 'deriving' clause of a data type declaration
Encountered in GHC version >=7.10
https://wiki.haskell.org/Functor-Applicative-Monad_Proposal
