### PR TITLE
updated LogAnalysis to build a tree and order the logs

### DIFF
--- a/02-adt/LogAnalysis.hs
+++ b/02-adt/LogAnalysis.hs
@@ -52,7 +52,7 @@ inOrder (Node left lmsg right) = inOrder left ++ [lmsg] ++ inOrder right
 -- corresponding to any errors with a severity of 50 or greater, sorted by
 -- timestamp.
 whatWentWrong :: [LogMessage] -> [String]
-whatWentWrong = extractMessage . filter (severe 50)
+whatWentWrong = extractMessage . inOrder . build . filter (severe 50)
 
 -- Returns True only when it's a Error with level > minLvl
 severe :: Int -> LogMessage -> Bool


### PR DESCRIPTION
Hi,

I noticed a little thing in `LogAnalysis.hs` in homework 2 where the `whatWentWrong` method was not ordering the logs, only filtering and printing them. Added in the steps to first build a tree then sort it in order before extracting the messages. Using `error.log`, output goes from:

```
[
"Twenty seconds remaining until out-of-mustard condition",
"Hard drive failure: insufficient mustard",
"Empty mustard reservoir! Attempting to recover...",
"Depletion of mustard stores detected!",
"Recovery failed! Initiating shutdown sequence",
"All backup mustardwatches are busy",
"Mustardwatch opened, please close for proper functioning!",
"Ten seconds remaining until out-of-mustard condition"
]
```

to:

```
[
"Mustardwatch opened, please close for proper functioning!",
"All backup mustardwatches are busy",
"Depletion of mustard stores detected!",
"Hard drive failure: insufficient mustard",
"Twenty seconds remaining until out-of-mustard condition",
"Ten seconds remaining until out-of-mustard condition",
"Empty mustard reservoir! Attempting to recover...",
"Recovery failed! Initiating shutdown sequence"
]
```

Which I think looks more correct?
